### PR TITLE
生成字体文件改成同步

### DIFF
--- a/lib/helper/engine.js
+++ b/lib/helper/engine.js
@@ -277,7 +277,7 @@ fontEngine.convert = (function() {
 
   var _writeFile = function(output, outFonts) {
     _.each(outFonts, function(font, type) {
-      fs.writeFile(output + '.' + type, font)
+      fs.writeFileSync(output + '.' + type, font)
     })
   }
 


### PR DESCRIPTION
具体看issue [https://github.com/purplebamboo/font-carrier/issues/3](https://github.com/purplebamboo/font-carrier/issues/3)
由于业务场景需要对字体文件进行操作，output方法没有提供回调，这里改成同步