### PR TITLE
支持配置svg2ttf的options参数

### DIFF
--- a/lib/helper/engine.js
+++ b/lib/helper/engine.js
@@ -16,16 +16,16 @@ var fontEngine = {
     if (Buffer.isBuffer(input)) return input
     return new Buffer(input)
   },
-  svg2ttf: function(input) {
+  svg2ttf: function(input, options) {
     if (Buffer.isBuffer(input)) input = input.toString()
-    return new Buffer(svg2ttf(input).buffer)
+    return new Buffer(svg2ttf(input, options).buffer)
   },
-  svg2eot: function(input) {
-    var ttfBuffer = this.svg2ttf(input)
+  svg2eot: function(input, options) {
+    var ttfBuffer = this.svg2ttf(input, options)
     return this.ttf2eot(ttfBuffer);
   },
-  svg2woff: function(input) {
-    var ttfBuffer = this.svg2ttf(input)
+  svg2woff: function(input, options) {
+    var ttfBuffer = this.svg2ttf(input, options)
     return this.ttf2woff(ttfBuffer);
   },
   ttf2ttf: function(input) {
@@ -259,7 +259,7 @@ fontEngine.convert = (function() {
 
 
 
-  var _convert = function(svgFontBuffer, outputTypes) {
+  var _convert = function(svgFontBuffer, outputTypes, options) {
     var result = {}
 
     var preKey = 'svg'
@@ -271,7 +271,7 @@ fontEngine.convert = (function() {
       if (type === 'svg') {
         result[type] = input
       } else {
-        result[type] = fontEngine['ttf2' + type](ttfBuffer)
+        result[type] = fontEngine['ttf2' + type](ttfBuffer, options)
       }
     })
 
@@ -295,7 +295,7 @@ fontEngine.convert = (function() {
       return
     }
 
-    var outFonts = _convert(inputBuffer, outputTypes)
+    var outFonts = _convert(inputBuffer, outputTypes, options)
     if (outputPath) {
       _writeFile(outputPath, outFonts)
     }

--- a/lib/helper/engine.js
+++ b/lib/helper/engine.js
@@ -265,7 +265,7 @@ fontEngine.convert = (function() {
     var preKey = 'svg'
     var input = svgFontBuffer
 
-    var ttfBuffer = fontEngine.svg2ttf(input)
+    var ttfBuffer = fontEngine.svg2ttf(input, options)
 
     _.each(outputTypes, function(type, k) {
       if (type === 'svg') {


### PR DESCRIPTION
详情见 issue #16 
考虑到使用的方便以及后续参数的复用，这边选择将Font类的output方法的配置和svg2ttf的options配置扁平化放在一起。