### PR TITLE
Fix: retain space characters when parsing fonts

### DIFF
--- a/lib/helper/engine.js
+++ b/lib/helper/engine.js
@@ -142,6 +142,16 @@ fontEngine.parse = (function() {
             }
 
           })
+        } else if ([32, 12288].indexOf(g.unicode) > -1) {
+          // space characters don't have path data
+          unicode = '&#x' + (g.unicode).toString(16) + ';'
+          fontObjs.glyphs[unicode] = {
+            d: path,
+            unicode: unicode,
+            name: g.name || 'uni' + g.unicode,
+            horizAdvX: g.advanceWidth,
+            vertAdvY: fontObjs.options.vertAdvY
+          }
         }
       } catch (e) {
         //todo debug options


### PR DESCRIPTION
中英文空格字符的 `path` 是空字符串，需要单独解析，不然 minify 出来的字体没有空格，在浏览器使用会 fallback 到 serif 字体